### PR TITLE
cloud_firestore: changes-only snapshotChanges + batched cold-start delivery (bom_4.16.1-a)

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/cloud_firestore/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        //mavenLocal()
+        mavenLocal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.3.0'
@@ -19,7 +19,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        //mavenLocal()
+        mavenLocal()
     }
 }
 
@@ -65,15 +65,15 @@ android {
 
     dependencies {
         api firebaseCoreProject
-        implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
-        implementation 'com.google.firebase:firebase-firestore'
+//        implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
+//        implementation 'com.google.firebase:firebase-firestore'
         // SwineTech: to consume a locally-built CUSTOM firebase-firestore AAR, enable the
         // mavenLocal() lines above and uncomment these. Versions track BOM 4.16.1 (firebase-bom
         // 34.15.0): Firestore resolves to 26.4.0 -> build the fork AAR as 26.4.0-a; its transitive
         // deps are firebase-common 22.0.1 + play-services-tasks 18.4.0. See SWINETECH_BOM_PORT.md.
-        //implementation 'com.google.firebase:firebase-firestore:26.4.0-a'
-        //implementation 'com.google.firebase:firebase-common:22.0.1'
-        //implementation 'com.google.android.gms:play-services-tasks:18.4.0'
+        implementation 'com.google.firebase:firebase-firestore:26.4.0-a'
+        implementation 'com.google.firebase:firebase-common:22.0.1'
+        implementation 'com.google.android.gms:play-services-tasks:18.4.0'
     }
 }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -334,7 +334,7 @@ public class FlutterFirebaseFirestorePlugin
       FirebaseFirestore firestore = FirebaseFirestore.getInstance(app, pigeonApp.getDatabaseURL());
       firestore.setFirestoreSettings(getSettingsFromPigeon(pigeonApp));
 
-      firestore.setLoggingEnabled(true); // Can enable for debugging.
+      firestore.setLoggingEnabled(false); // Can enable for debugging.
 
       FlutterFirebaseFirestorePlugin.setCachedFirebaseFirestoreInstanceForKey(
           firestore, pigeonApp.getDatabaseURL());

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -334,7 +334,7 @@ public class FlutterFirebaseFirestorePlugin
       FirebaseFirestore firestore = FirebaseFirestore.getInstance(app, pigeonApp.getDatabaseURL());
       firestore.setFirestoreSettings(getSettingsFromPigeon(pigeonApp));
 
-      firestore.setLoggingEnabled(false); // Can enable for debugging.
+      firestore.setLoggingEnabled(true); // Can enable for debugging.
 
       FlutterFirebaseFirestorePlugin.setCachedFirebaseFirestoreInstanceForKey(
           firestore, pigeonApp.getDatabaseURL());

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/GeneratedAndroidFirebaseFirestore.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/GeneratedAndroidFirebaseFirestore.java
@@ -1178,6 +1178,19 @@ public class GeneratedAndroidFirebaseFirestore {
       this.metadata = setterArg;
     }
 
+    // SwineTech (hand-added field; keep in sync if this file is ever regenerated): true for every
+    // batch of a chunked initial snapshot except the last, so the consumer can detect when the
+    // whole initial result set has been delivered. Nullable/absent means "not partial".
+    private @Nullable Boolean isPartial;
+
+    public @Nullable Boolean getIsPartial() {
+      return isPartial;
+    }
+
+    public void setIsPartial(@Nullable Boolean setterArg) {
+      this.isPartial = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     InternalQuerySnapshotChanges() {}
 
@@ -1218,19 +1231,29 @@ public class GeneratedAndroidFirebaseFirestore {
         return this;
       }
 
+      private @Nullable Boolean isPartial;
+
+      @CanIgnoreReturnValue
+      public @NonNull Builder setIsPartial(@Nullable Boolean setterArg) {
+        this.isPartial = setterArg;
+        return this;
+      }
+
       public @NonNull InternalQuerySnapshotChanges build() {
         InternalQuerySnapshotChanges pigeonReturn = new InternalQuerySnapshotChanges();
         pigeonReturn.setDocumentChanges(documentChanges);
         pigeonReturn.setMetadata(metadata);
+        pigeonReturn.setIsPartial(isPartial);
         return pigeonReturn;
       }
     }
 
     @NonNull
     public ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<>(2);
+      ArrayList<Object> toListResult = new ArrayList<>(3);
       toListResult.add(documentChanges);
       toListResult.add(metadata);
+      toListResult.add(isPartial);
       return toListResult;
     }
 
@@ -1241,6 +1264,10 @@ public class GeneratedAndroidFirebaseFirestore {
       pigeonResult.setDocumentChanges((List<InternalDocumentChange>) documentChanges);
       Object metadata = pigeonVar_list.get(1);
       pigeonResult.setMetadata((InternalSnapshotMetadata) metadata);
+      // SwineTech: length-tolerant — messages from platforms that don't set isPartial encode only
+      // the first two elements.
+      Object isPartial = pigeonVar_list.size() > 2 ? pigeonVar_list.get(2) : null;
+      pigeonResult.setIsPartial((Boolean) isPartial);
       return pigeonResult;
     }
   }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/GeneratedAndroidFirebaseFirestore.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/GeneratedAndroidFirebaseFirestore.java
@@ -1204,12 +1204,15 @@ public class GeneratedAndroidFirebaseFirestore {
       }
       InternalQuerySnapshotChanges that = (InternalQuerySnapshotChanges) o;
       return pigeonDeepEquals(documentChanges, that.documentChanges)
-          && pigeonDeepEquals(metadata, that.metadata);
+          && pigeonDeepEquals(metadata, that.metadata)
+          // SwineTech (hand-added): keep in sync with hashCode/toList — isPartial
+          // participates in equality so equal objects always share a hashCode.
+          && pigeonDeepEquals(isPartial, that.isPartial);
     }
 
     @Override
     public int hashCode() {
-      Object[] fields = new Object[] {getClass(), documentChanges, metadata};
+      Object[] fields = new Object[] {getClass(), documentChanges, metadata, isPartial};
       return pigeonDeepHashCode(fields);
     }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
@@ -36,16 +36,22 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
 
   ListenSource source;
 
-  // SwineTech: a large initial snapshot arrives as the whole result set expressed as ADDED
-  // document changes. Delivering it as ONE method-channel message materializes the whole herd at
-  // once (a single multi-MB serialized buffer with every pigeon object live together). Split large
-  // change lists into batches of this size, one message per batch, so no single allocation spans
-  // the whole result set. Ordinary (smaller) deltas are sent as one message.
+  // SwineTech: any snapshot whose change set exceeds this size is split into batches of this many
+  // document changes, one method-channel message per batch. This is NOT only the initial load — a
+  // large delta (bulk write, or reconnect after extended offline edits) is split too. Delivering a
+  // huge change set as ONE message forces a single contiguous multi-MB allocation (an ArrayList of
+  // pigeon objects plus the serialized ByteBuffer) — the usual proximate OOM / fragmentation
+  // trigger. Splitting guarantees no single allocation spans the whole result set.
   //
-  // Batches are emitted synchronously (no inter-batch pacing): memory during the initial load is
-  // already bounded by the fork's per-field cache + changes-only projected View + byte-backed
-  // ObjectValue, so pacing only added load latency and queued batch buffers for no memory win.
-  private static final int INITIAL_DELIVERY_BATCH_SIZE = 500;
+  // It does NOT by itself bound peak memory: getDocumentChanges() below holds the full SDK-side
+  // change list live for the whole callback, and with synchronous emit the per-batch buffers can
+  // queue before Dart drains them. The primary memory lever is setChangesOnly(true) (below) plus
+  // the fork's changes-only projected View / per-field cache / byte-backed ObjectValue — see
+  // charlotte/SWINETECH_FIREBASE_FORK.md.
+  //
+  // Batches are emitted synchronously (no inter-batch pacing): pacing was measured to add load
+  // latency for no memory win, so it was dropped.
+  private static final int DELIVERY_BATCH_SIZE = 500;
 
   public QuerySnapshotChangesStreamHandler(
       Query query,
@@ -83,31 +89,45 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
                 // nested `InternalDocumentChange` / `InternalSnapshotMetadata` with their
                 // proper type codes. Pigeon 26 no longer flattens nested types via `.toList()`.
                 //
-                // SwineTech: a large snapshot (notably the initial one, which carries the whole
-                // result set as ADDED changes) is delivered in batches so peak memory during
-                // conversion + serialization stays bounded to one batch rather than the whole
-                // result set. The consumer merges document changes incrementally by document id,
-                // so one logical snapshot split across several sequential events is equivalent.
-                List<DocumentChange> documentChanges = querySnapshotChanges.getDocumentChanges();
-                SnapshotMetadata metadata = querySnapshotChanges.getMetadata();
-                int total = documentChanges.size();
-                if (total <= INITIAL_DELIVERY_BATCH_SIZE) {
-                  events.success(
-                      PigeonParser.toPigeonQuerySnapshotChanges(
-                          metadata, documentChanges, serverTimestampBehavior, false));
-                } else {
-                  for (int start = 0; start < total; start += INITIAL_DELIVERY_BATCH_SIZE) {
-                    int end = Math.min(start + INITIAL_DELIVERY_BATCH_SIZE, total);
-                    // isPartial is true for every batch except the last, so the consumer knows when
-                    // the whole initial result set has been delivered.
-                    boolean isPartial = end < total;
+                // SwineTech: a large change set is delivered as several sequential events (see
+                // DELIVERY_BATCH_SIZE). This plugin does NOT merge them — the application consumer
+                // must merge the batches (by document id) and treat isPartial == false as the
+                // signal that the whole change set has arrived (see pigflow #244).
+                //
+                // The batch loop is guarded: unlike the old single-message path, a failure part
+                // way through (conversion, codec serialization, ...) after one or more
+                // isPartial=true batches would otherwise strand the consumer waiting for the
+                // terminal isPartial=false batch that never comes. On failure, terminate the
+                // stream deterministically, mirroring the listener-error branch above.
+                // (OutOfMemoryError is an Error, not an Exception, and is intentionally not
+                // caught — recovery after OOM is unreliable.)
+                try {
+                  List<DocumentChange> documentChanges = querySnapshotChanges.getDocumentChanges();
+                  SnapshotMetadata metadata = querySnapshotChanges.getMetadata();
+                  int total = documentChanges.size();
+                  if (total <= DELIVERY_BATCH_SIZE) {
                     events.success(
                         PigeonParser.toPigeonQuerySnapshotChanges(
-                            metadata,
-                            documentChanges.subList(start, end),
-                            serverTimestampBehavior,
-                            isPartial));
+                            metadata, documentChanges, serverTimestampBehavior, false));
+                  } else {
+                    for (int start = 0; start < total; start += DELIVERY_BATCH_SIZE) {
+                      int end = Math.min(start + DELIVERY_BATCH_SIZE, total);
+                      // isPartial is true for every batch except the last, so the consumer knows
+                      // when the whole change set has been delivered.
+                      boolean isPartial = end < total;
+                      events.success(
+                          PigeonParser.toPigeonQuerySnapshotChanges(
+                              metadata,
+                              documentChanges.subList(start, end),
+                              serverTimestampBehavior,
+                              isPartial));
+                    }
                   }
+                } catch (Exception e) {
+                  Map<String, String> exceptionDetails = ExceptionConverter.createDetails(e);
+                  events.error(DEFAULT_ERROR_CODE, e.getMessage(), exceptionDetails);
+                  events.endOfStream();
+                  onCancel(null);
                 }
               }
             });

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
@@ -8,16 +8,21 @@ package io.flutter.plugins.firebase.firestore.streamhandler;
 
 import static io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin.DEFAULT_ERROR_CODE;
 
+import android.os.Handler;
+import android.os.Looper;
+import com.google.firebase.firestore.DocumentChange;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.ListenSource;
 import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.SnapshotListenOptions;
+import com.google.firebase.firestore.SnapshotMetadata;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
 import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
 import io.flutter.plugins.firebase.firestore.utils.PigeonParser;
+import java.util.List;
 import java.util.Map;
 
 // SwineTech: streams a "true" query snapshot that carries only the changed
@@ -32,6 +37,21 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
   DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior;
 
   ListenSource source;
+
+  // SwineTech: a large initial snapshot arrives as the whole result set expressed as ADDED
+  // document changes. Delivering it as a single method-channel message materializes every
+  // document at once (pigeon objects + serialized buffer) and drives the cold-start memory peak.
+  // Split large change lists into batches of this size, emitting one message per batch, so peak
+  // memory stays bounded to a single batch. Ordinary (smaller) deltas are sent as one message.
+  private static final int INITIAL_DELIVERY_BATCH_SIZE = 500;
+
+  // SwineTech: batches of a large snapshot are delivered one per main-looper turn (with a short
+  // gap) rather than in a synchronous loop, so the concurrent GC can reclaim each batch's transient
+  // inflation (getData maps + pigeon objects) before the next is built. Without this the whole
+  // herd's inflation piles up as garbage in one burst and drives the cold-start peak.
+  private static final long BATCH_DELIVERY_INTERVAL_MS = 8;
+
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
   public QuerySnapshotChangesStreamHandler(
       Query query,
@@ -50,6 +70,9 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
     SnapshotListenOptions.Builder optionsBuilder = new SnapshotListenOptions.Builder();
     optionsBuilder.setMetadataChanges(metadataChanges);
     optionsBuilder.setSource(source);
+    // SwineTech: this handler only ever surfaces document changes (never the full result set), so
+    // let the Firestore SDK retain projected documents instead of full data in the query view.
+    optionsBuilder.setChangesOnly(true);
 
     listenerRegistration =
         query.addSnapshotListener(
@@ -65,11 +88,48 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
                 // Emit the Pigeon object directly; the Pigeon-aware codec serializes the
                 // nested `InternalDocumentChange` / `InternalSnapshotMetadata` with their
                 // proper type codes. Pigeon 26 no longer flattens nested types via `.toList()`.
-                events.success(
-                    PigeonParser.toPigeonQuerySnapshotChanges(
-                        querySnapshotChanges, serverTimestampBehavior));
+                //
+                // SwineTech: a large snapshot (notably the initial one, which carries the whole
+                // result set as ADDED changes) is delivered in batches so peak memory during
+                // conversion + serialization stays bounded to one batch rather than the whole
+                // result set. The consumer merges document changes incrementally by document id,
+                // so one logical snapshot split across several sequential events is equivalent.
+                List<DocumentChange> documentChanges = querySnapshotChanges.getDocumentChanges();
+                SnapshotMetadata metadata = querySnapshotChanges.getMetadata();
+                if (documentChanges.size() <= INITIAL_DELIVERY_BATCH_SIZE) {
+                  events.success(
+                      PigeonParser.toPigeonQuerySnapshotChanges(
+                          metadata, documentChanges, serverTimestampBehavior, false));
+                } else {
+                  // Deliver the first batch now and pace the remaining batches across main-looper
+                  // turns (see deliverBatch) so the GC can reclaim each batch before the next.
+                  deliverBatch(events, metadata, documentChanges, 0);
+                }
               }
             });
+  }
+
+  // SwineTech: delivers one batch of a large snapshot, then schedules the next on the main looper
+  // (rather than looping synchronously) so the concurrent GC reclaims this batch's transient
+  // inflation before the next is built. isPartial is true for every batch except the last, so the
+  // consumer only treats the initial result set as complete once the final (non-partial) batch
+  // arrives.
+  private void deliverBatch(
+      EventSink events, SnapshotMetadata metadata, List<DocumentChange> changes, int start) {
+    // Stop if the stream was torn down (onCancel / onError) while batches were still pending.
+    if (listenerRegistration == null) {
+      return;
+    }
+    int total = changes.size();
+    int end = Math.min(start + INITIAL_DELIVERY_BATCH_SIZE, total);
+    boolean isPartial = end < total;
+    events.success(
+        PigeonParser.toPigeonQuerySnapshotChanges(
+            metadata, changes.subList(start, end), serverTimestampBehavior, isPartial));
+    if (isPartial) {
+      mainHandler.postDelayed(
+          () -> deliverBatch(events, metadata, changes, end), BATCH_DELIVERY_INTERVAL_MS);
+    }
   }
 
   @Override

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
@@ -8,8 +8,6 @@ package io.flutter.plugins.firebase.firestore.streamhandler;
 
 import static io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin.DEFAULT_ERROR_CODE;
 
-import android.os.Handler;
-import android.os.Looper;
 import com.google.firebase.firestore.DocumentChange;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.ListenSource;
@@ -39,19 +37,15 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
   ListenSource source;
 
   // SwineTech: a large initial snapshot arrives as the whole result set expressed as ADDED
-  // document changes. Delivering it as a single method-channel message materializes every
-  // document at once (pigeon objects + serialized buffer) and drives the cold-start memory peak.
-  // Split large change lists into batches of this size, emitting one message per batch, so peak
-  // memory stays bounded to a single batch. Ordinary (smaller) deltas are sent as one message.
+  // document changes. Delivering it as ONE method-channel message materializes the whole herd at
+  // once (a single multi-MB serialized buffer with every pigeon object live together). Split large
+  // change lists into batches of this size, one message per batch, so no single allocation spans
+  // the whole result set. Ordinary (smaller) deltas are sent as one message.
+  //
+  // Batches are emitted synchronously (no inter-batch pacing): memory during the initial load is
+  // already bounded by the fork's per-field cache + changes-only projected View + byte-backed
+  // ObjectValue, so pacing only added load latency and queued batch buffers for no memory win.
   private static final int INITIAL_DELIVERY_BATCH_SIZE = 500;
-
-  // SwineTech: batches of a large snapshot are delivered one per main-looper turn (with a short
-  // gap) rather than in a synchronous loop, so the concurrent GC can reclaim each batch's transient
-  // inflation (getData maps + pigeon objects) before the next is built. Without this the whole
-  // herd's inflation piles up as garbage in one burst and drives the cold-start peak.
-  private static final long BATCH_DELIVERY_INTERVAL_MS = 8;
-
-  private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
   public QuerySnapshotChangesStreamHandler(
       Query query,
@@ -96,40 +90,27 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
                 // so one logical snapshot split across several sequential events is equivalent.
                 List<DocumentChange> documentChanges = querySnapshotChanges.getDocumentChanges();
                 SnapshotMetadata metadata = querySnapshotChanges.getMetadata();
-                if (documentChanges.size() <= INITIAL_DELIVERY_BATCH_SIZE) {
+                int total = documentChanges.size();
+                if (total <= INITIAL_DELIVERY_BATCH_SIZE) {
                   events.success(
                       PigeonParser.toPigeonQuerySnapshotChanges(
                           metadata, documentChanges, serverTimestampBehavior, false));
                 } else {
-                  // Deliver the first batch now and pace the remaining batches across main-looper
-                  // turns (see deliverBatch) so the GC can reclaim each batch before the next.
-                  deliverBatch(events, metadata, documentChanges, 0);
+                  for (int start = 0; start < total; start += INITIAL_DELIVERY_BATCH_SIZE) {
+                    int end = Math.min(start + INITIAL_DELIVERY_BATCH_SIZE, total);
+                    // isPartial is true for every batch except the last, so the consumer knows when
+                    // the whole initial result set has been delivered.
+                    boolean isPartial = end < total;
+                    events.success(
+                        PigeonParser.toPigeonQuerySnapshotChanges(
+                            metadata,
+                            documentChanges.subList(start, end),
+                            serverTimestampBehavior,
+                            isPartial));
+                  }
                 }
               }
             });
-  }
-
-  // SwineTech: delivers one batch of a large snapshot, then schedules the next on the main looper
-  // (rather than looping synchronously) so the concurrent GC reclaims this batch's transient
-  // inflation before the next is built. isPartial is true for every batch except the last, so the
-  // consumer only treats the initial result set as complete once the final (non-partial) batch
-  // arrives.
-  private void deliverBatch(
-      EventSink events, SnapshotMetadata metadata, List<DocumentChange> changes, int start) {
-    // Stop if the stream was torn down (onCancel / onError) while batches were still pending.
-    if (listenerRegistration == null) {
-      return;
-    }
-    int total = changes.size();
-    int end = Math.min(start + INITIAL_DELIVERY_BATCH_SIZE, total);
-    boolean isPartial = end < total;
-    events.success(
-        PigeonParser.toPigeonQuerySnapshotChanges(
-            metadata, changes.subList(start, end), serverTimestampBehavior, isPartial));
-    if (isPartial) {
-      mainHandler.postDelayed(
-          () -> deliverBatch(events, metadata, changes, end), BATCH_DELIVERY_INTERVAL_MS);
-    }
   }
 
   @Override

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/utils/PigeonParser.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/utils/PigeonParser.java
@@ -75,12 +75,31 @@ public class PigeonParser {
       toPigeonQuerySnapshotChanges(
           com.google.firebase.firestore.QuerySnapshot querySnapshot,
           DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
+    return toPigeonQuerySnapshotChanges(
+        querySnapshot.getMetadata(),
+        querySnapshot.getDocumentChanges(),
+        serverTimestampBehavior,
+        false);
+  }
+
+  // SwineTech: builds an InternalQuerySnapshotChanges from an explicit metadata + document-change
+  // list, so a large snapshot's changes can be delivered in batches (see
+  // QuerySnapshotChangesStreamHandler) instead of materializing the whole result set in one
+  // method-channel message. isPartial is true for every batch except the last of a chunked
+  // delivery, so the consumer can tell when the whole initial result set has arrived.
+  public static GeneratedAndroidFirebaseFirestore.InternalQuerySnapshotChanges
+      toPigeonQuerySnapshotChanges(
+          com.google.firebase.firestore.SnapshotMetadata metadata,
+          List<com.google.firebase.firestore.DocumentChange> documentChanges,
+          DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior,
+          boolean isPartial) {
     GeneratedAndroidFirebaseFirestore.InternalQuerySnapshotChanges.Builder
         pigeonQuerySnapshotChanges =
             new GeneratedAndroidFirebaseFirestore.InternalQuerySnapshotChanges.Builder();
-    pigeonQuerySnapshotChanges.setMetadata(toPigeonSnapshotMetadata(querySnapshot.getMetadata()));
+    pigeonQuerySnapshotChanges.setMetadata(toPigeonSnapshotMetadata(metadata));
     pigeonQuerySnapshotChanges.setDocumentChanges(
-        toPigeonDocumentChanges(querySnapshot.getDocumentChanges(), serverTimestampBehavior));
+        toPigeonDocumentChanges(documentChanges, serverTimestampBehavior));
+    pigeonQuerySnapshotChanges.setIsPartial(isPartial);
     return pigeonQuerySnapshotChanges.build();
   }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
@@ -14,13 +14,23 @@ abstract class QuerySnapshotChanges<T extends Object?> {
   /// Returns the [SnapshotMetadata] for this snapshot.
   SnapshotMetadata get metadata;
 
-  /// Whether this is a non-final batch of a chunked initial snapshot. When true,
-  /// more batches for the same logical snapshot will follow. The whole initial
-  /// result set has arrived once a snapshot with this set to false is received.
-  /// Ordinary (delta) snapshots are never partial.
+  /// Whether this is a non-final batch of a snapshot whose change set was too
+  /// large to deliver in a single platform message and was split into batches.
+  ///
+  /// True for every batch except the last; the whole change set has arrived once
+  /// a snapshot with this set to `false` is received. The application consumer is
+  /// responsible for merging the batches (by document id) and treating
+  /// `isPartial == false` as the completion signal — this layer does not merge.
+  ///
+  /// Any snapshot exceeding the delivery batch size is split, including large
+  /// deltas (e.g. a bulk write, or reconnecting after extended offline edits) —
+  /// not just the initial load.
   bool get isPartial;
 
   /// Returns the size (number of documents) of this snapshot.
+  ///
+  /// When a large snapshot is split (see [isPartial]), this is the size of *this
+  /// batch* (≤ the delivery batch size), not the total for the logical snapshot.
   int get size;
 }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
@@ -14,6 +14,12 @@ abstract class QuerySnapshotChanges<T extends Object?> {
   /// Returns the [SnapshotMetadata] for this snapshot.
   SnapshotMetadata get metadata;
 
+  /// Whether this is a non-final batch of a chunked initial snapshot. When true,
+  /// more batches for the same logical snapshot will follow. The whole initial
+  /// result set has arrived once a snapshot with this set to false is received.
+  /// Ordinary (delta) snapshots are never partial.
+  bool get isPartial;
+
   /// Returns the size (number of documents) of this snapshot.
   int get size;
 }
@@ -38,6 +44,9 @@ class _JsonQuerySnapshotChanges
 
   @override
   SnapshotMetadata get metadata => SnapshotMetadata._(_delegate.metadata);
+
+  @override
+  bool get isPartial => _delegate.isPartial;
 
   @override
   int get size => _delegate.size;
@@ -72,6 +81,9 @@ class _WithConverterQuerySnapshotChanges<T extends Object?>
 
   @override
   SnapshotMetadata get metadata => _originalQuerySnapshotChanges.metadata;
+
+  @override
+  bool get isPartial => _originalQuerySnapshotChanges.isPartial;
 
   @override
   int get size => _originalQuerySnapshotChanges.size;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot_changes.dart
@@ -29,5 +29,7 @@ class MethodChannelQuerySnapshotChanges extends QuerySnapshotChangesPlatform {
             SnapshotMetadataPlatform(
               data.metadata.hasPendingWrites,
               data.metadata.isFromCache,
-            ));
+            ),
+            // SwineTech: null (from platforms that don't set it) == not partial.
+            data.isPartial ?? false);
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -591,7 +591,10 @@ class InternalQuerySnapshotChanges {
       return true;
     }
     return _deepEquals(documentChanges, other.documentChanges) &&
-        _deepEquals(metadata, other.metadata);
+        _deepEquals(metadata, other.metadata) &&
+        // SwineTech (hand-added): keep in sync with hashCode/_toList — isPartial
+        // participates in equality so equal objects always share a hashCode.
+        _deepEquals(isPartial, other.isPartial);
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -543,16 +543,24 @@ class InternalQuerySnapshotChanges {
   InternalQuerySnapshotChanges({
     required this.documentChanges,
     required this.metadata,
+    this.isPartial,
   });
 
   List<InternalDocumentChange?> documentChanges;
 
   InternalSnapshotMetadata metadata;
 
+  // SwineTech (hand-added field; keep in sync if this file is ever regenerated): true for every
+  // batch of a chunked initial snapshot except the last, letting the consumer detect when the
+  // whole initial result set has arrived. Null/absent (e.g. from platforms that don't set it)
+  // means "not partial".
+  bool? isPartial;
+
   List<Object?> _toList() {
     return <Object?>[
       documentChanges,
       metadata,
+      isPartial,
     ];
   }
 
@@ -566,6 +574,9 @@ class InternalQuerySnapshotChanges {
       documentChanges:
           (result[0]! as List<Object?>).cast<InternalDocumentChange?>(),
       metadata: result[1]! as InternalSnapshotMetadata,
+      // SwineTech: length-tolerant so 2-element messages (from platforms that don't set
+      // isPartial) decode as null instead of throwing a RangeError.
+      isPartial: result.length > 2 ? result[2] as bool? : null,
     );
   }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
@@ -15,8 +15,9 @@ class QuerySnapshotChangesPlatform extends PlatformInterface {
   /// Create a [QuerySnapshotChangesPlatform]
   QuerySnapshotChangesPlatform(
     this.docChanges,
-    this.metadata,
-  ) : super(token: _token);
+    this.metadata, [
+    this.isPartial = false,
+  ]) : super(token: _token);
 
   static final Object _token = Object();
 
@@ -36,6 +37,12 @@ class QuerySnapshotChangesPlatform extends PlatformInterface {
 
   /// Metadata for the document
   final SnapshotMetadataPlatform metadata;
+
+  /// Whether this is a non-final batch of a chunked initial snapshot. When true,
+  /// more batches for the same logical snapshot will follow; the whole initial
+  /// result set has arrived once a snapshot with this set to false is received.
+  /// Ordinary (delta) snapshots are never partial.
+  final bool isPartial;
 
   /// The number of documents with changes in this [QuerySnapshotChangesPlatform].
   int get size => docChanges.length;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
@@ -38,12 +38,20 @@ class QuerySnapshotChangesPlatform extends PlatformInterface {
   /// Metadata for the document
   final SnapshotMetadataPlatform metadata;
 
-  /// Whether this is a non-final batch of a chunked initial snapshot. When true,
-  /// more batches for the same logical snapshot will follow; the whole initial
-  /// result set has arrived once a snapshot with this set to false is received.
-  /// Ordinary (delta) snapshots are never partial.
+  /// Whether this is a non-final batch of a snapshot whose change set was too
+  /// large to deliver in a single platform message and was split into batches.
+  ///
+  /// True for every batch except the last; the whole change set has arrived once
+  /// a snapshot with this set to `false` is received. The application consumer
+  /// must merge the batches (by document id) and treat `isPartial == false` as
+  /// the completion signal — this layer does not merge. Any snapshot exceeding
+  /// the delivery batch size is split, including large deltas — not just the
+  /// initial load.
   final bool isPartial;
 
   /// The number of documents with changes in this [QuerySnapshotChangesPlatform].
+  ///
+  /// When a large snapshot is split (see [isPartial]), this is the size of *this
+  /// batch*, not the total for the logical snapshot.
   int get size => docChanges.length;
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pigeons/messages.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pigeons/messages.dart
@@ -122,10 +122,19 @@ class InternalQuerySnapshotChanges {
   const InternalQuerySnapshotChanges({
     required this.documentChanges,
     required this.metadata,
+    this.isPartial,
   });
 
   final List<InternalDocumentChange?> documentChanges;
   final InternalSnapshotMetadata metadata;
+
+  // SwineTech: true for every batch of a split large snapshot except the last, so the
+  // consumer can detect when the whole change set has been delivered; null/absent means
+  // "not partial". Declared here in the pigeon source of truth so a regen keeps the field
+  // in encode/decode instead of silently dropping it. NB: pigeon is hand-maintained in
+  // this fork — do not regenerate (see SWINETECH_BOM_PORT.md); this mirrors the field
+  // hand-added to the generated messages.pigeon.dart / GeneratedAndroidFirebaseFirestore.java.
+  final bool? isPartial;
 }
 
 class InternalPipelineResult {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/query_snapshot_changes_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/query_snapshot_changes_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// SwineTech: pins the hand-added `isPartial` field on the (hand-maintained) pigeon
+// type and its MethodChannel wrapper — the length-tolerant decode, the encode/equals
+// contract, and the null -> false coercion. See PR #14.
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_query_snapshot_changes.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+// ignore: avoid_implementing_value_types
+class _MockFirestore extends Mock implements FirebaseFirestorePlatform {}
+
+InternalSnapshotMetadata _metadata({
+  bool hasPendingWrites = false,
+  bool isFromCache = false,
+}) =>
+    InternalSnapshotMetadata(
+      hasPendingWrites: hasPendingWrites,
+      isFromCache: isFromCache,
+    );
+
+InternalQuerySnapshotChanges _changes(bool? isPartial, {InternalSnapshotMetadata? metadata}) =>
+    InternalQuerySnapshotChanges(
+      documentChanges: const <InternalDocumentChange?>[],
+      metadata: metadata ?? _metadata(),
+      isPartial: isPartial,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('InternalQuerySnapshotChanges.decode isPartial', () {
+    test('2-element message decodes as null instead of throwing RangeError', () {
+      // Platforms that don't set isPartial (iOS/Windows/test_api) encode only
+      // documentChanges + metadata; the length-tolerant decode must tolerate it.
+      final decoded = InternalQuerySnapshotChanges.decode(
+        <Object?>[<Object?>[], _metadata()],
+      );
+      expect(decoded.isPartial, isNull);
+    });
+
+    test('3-element message preserves true / false / null', () {
+      for (final value in <bool?>[true, false, null]) {
+        final decoded = InternalQuerySnapshotChanges.decode(
+          <Object?>[<Object?>[], _metadata(), value],
+        );
+        expect(decoded.isPartial, value);
+      }
+    });
+
+    test('encode/decode round-trips isPartial', () {
+      for (final value in <bool?>[true, false, null]) {
+        final decoded =
+            InternalQuerySnapshotChanges.decode(_changes(value).encode());
+        expect(decoded.isPartial, value);
+      }
+    });
+  });
+
+  group('InternalQuerySnapshotChanges equality', () {
+    // Share one metadata instance so only isPartial varies.
+    final md = _metadata();
+    InternalQuerySnapshotChanges make(bool? isPartial) =>
+        _changes(isPartial, metadata: md);
+
+    test('isPartial participates in == and hashCode', () {
+      expect(make(true), equals(make(true)));
+      expect(make(true).hashCode, equals(make(true).hashCode));
+      expect(make(true), isNot(equals(make(false))));
+    });
+
+    test('null is distinct from false', () {
+      expect(make(null), isNot(equals(make(false))));
+    });
+  });
+
+  group('MethodChannelQuerySnapshotChanges isPartial coercion', () {
+    final firestore = _MockFirestore();
+
+    // Empty documentChanges => firestore is never dereferenced, so the mock needs
+    // no stubs; this isolates the isPartial/metadata mapping.
+    MethodChannelQuerySnapshotChanges wrap(bool? isPartial) =>
+        MethodChannelQuerySnapshotChanges(
+          firestore,
+          InternalQuerySnapshotChanges(
+            documentChanges: const <InternalDocumentChange?>[],
+            metadata: _metadata(hasPendingWrites: true),
+            isPartial: isPartial,
+          ),
+        );
+
+    test('null isPartial coerces to false', () {
+      expect(wrap(null).isPartial, isFalse);
+    });
+
+    test('true isPartial is preserved', () {
+      expect(wrap(true).isPartial, isTrue);
+    });
+
+    test('the added isPartial arg did not shift metadata / docChanges', () {
+      final result = wrap(true);
+      expect(result.docChanges, isEmpty);
+      expect(result.size, 0);
+      expect(result.metadata.hasPendingWrites, isTrue);
+      expect(result.metadata.isFromCache, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## FlutterFire fork — stream Firestore *changes* + batched cold-start delivery

Part of the SwineTech Firebase fork stack that fixes Charlotte's always-on `all_on_farm_sows` listener
OOM. This is the FlutterFire (Dart/Android plugin) half; it pairs with the `firebase-firestore` SDK
fork `26.4.0-a` (changes-only projected `View` — SwineTech-Inc/firebase-android-sdk#9).

**Base:** `SwineTech/bom_4.16.1` (the ported clean base, `e43d26e39`).
**Diff:** 3 commits — the streaming/delivery changes on top of the port.

### What it changes
- **`snapshotChanges()`** — a custom API returning `InternalQuerySnapshotChanges` (only document
  changes + metadata, never the full result set). The host handler
  (`QuerySnapshotChangesStreamHandler`) sets `setChangesOnly(true)`, driving the SDK fork's Track A
  projected `View` so the whole result set is never retained.
- **Batched cold-start delivery** — a large initial snapshot is split into `INITIAL_DELIVERY_BATCH_SIZE
  = 500` document-change batches (one method-channel message each) instead of a single whole-herd
  message that would re-materialize the entire herd at once. Each batch carries an **`isPartial`** flag
  (true for every batch except the last) so the consumer knows when the full initial set has arrived.
- **Synchronous delivery** (`9c0a4da99`) — batches are emitted in a synchronous loop; an earlier 8 ms
  inter-batch pacing was measured to add load latency with no memory benefit and was dropped.
- **`setLoggingEnabled(false)`** (`28adff9ef`) — silence the verbose Firestore `[Persistence]` logs in
  release/profile builds.

### ⚠️ Pigeon is hand-maintained — do not regenerate
A no-op regen with the pinned pigeon (26.3.4) diverges 2900+ lines. `isPartial` was hand-added to the
two runtime generated files (`GeneratedAndroidFirebaseFirestore.java`, `messages.pigeon.dart`) with a
length-tolerant Dart decode (`result.length > 2 ? result[2] as bool? : null`), leaving
iOS/Windows/test_api generated files untouched (they still emit 2-element lists → decode as null =
not-partial).

### Commits
- `dfad62c06` cloud_firestore: SwineTech snapshotChanges + batched/paced cold-start delivery
- `9c0a4da99` cloud_firestore: deliver initial snapshot synchronously (drop 8ms batch pacing)
- `28adff9ef` removing debug logging (setLoggingEnabled false)

> ⚠️ Push SwineTech branches to the `SwineTech-Inc` fork (`origin`) only — never to the public
> `firebase/flutterfire` upstream (the `actualFlutterfire` remote).
>
> Full stack rationale + old-vs-new metrics + re-fork runbook: `charlotte/SWINETECH_FIREBASE_FORK.md`
> (SwineTech-Inc/pigflow). App-side consumption: SwineTech-Inc/pigflow#244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
